### PR TITLE
Resolves Issue #8 with URL_REAUTHENTICATION_REQUESTED type enum.

### DIFF
--- a/src/IO.Swagger/model.agreements/AgreementEvent.cs
+++ b/src/IO.Swagger/model.agreements/AgreementEvent.cs
@@ -460,7 +460,13 @@ namespace IO.Swagger.model.agreements
             /// Enum WRITTENSIGNED for value: WRITTEN_SIGNED
             /// </summary>
             [EnumMember(Value = "WRITTEN_SIGNED")]
-            WRITTENSIGNED = 54
+            WRITTENSIGNED = 54,
+
+            /// <summary>
+            /// Enum URLREAUTHENTICATIONREQUESTED for value: URL_REAUTHENTICATION_REQUESTED
+            /// </summary>
+            [EnumMember(Value = "URL_REAUTHENTICATION_REQUESTED")]
+            URLREAUTHENTICATIONREQUESTED = 55
         }
 
         /// <summary>


### PR DESCRIPTION
Adds new enum type to prevent critical bug when deserializing to unknown TypeEnum.

## Description

Added new enum.

## Related Issue

Fixes [Issue #8](https://github.com/adobe-sign/AdobeSignCSharpSDK/issues/8)

## Motivation and Context

This change prevents legacy code from breaking. We, along with presumably many others, have code that up until this point, has been working pretty flawlessly.  At some point Adobe introduced a contract breaking change and did not update this library.

## How Has This Been Tested?

Since there are no tests in source code for TypeEnum, we performed manual testing. We have our own tests in our own source code that verify the code works.
## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Tests are commented out. So last two checkboxes are tautologically true.
